### PR TITLE
Fix webfac return for Telnet on AES version 1

### DIFF
--- a/zte_factroymode.py
+++ b/zte_factroymode.py
@@ -235,6 +235,7 @@ def dealFacAuth(Class: WebFac, ip, port, users, pws):
                 if webfac.checkLoginAuth():
                     print("facStep 4:")
                     print("OK!\n")
+                    return webfac
             elif version == 2:
                 print("facStep 3:")
                 if not webfac.sendInfo():


### PR DESCRIPTION
Missing "return webfac" if AES version is 1.
Tested succesfully on F601v6 and v7 GPON ONT